### PR TITLE
Enable going back in history with backpress on Android

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/WebviewActivity.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewActivity.java
@@ -76,6 +76,10 @@ public class WebviewActivity extends Activity {
 
     @Override
     public void onBackPressed() {
+        if(webView.canGoBack()){
+            webView.goBack();
+            return;
+        }
         FlutterWebviewPlugin.channel.invokeMethod("onBackPressed", null);
         super.onBackPressed();
     }


### PR DESCRIPTION
Otherwise, destroy the webview activity. The user is still able to immediately leave the webview with the button present on the top left corner. This change is only limited to Android.