### PR TITLE
use standard Activity as calling class to support FlutterFragmentActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.9
+
+- Android: remove the need to use FlutterActivity as base activity
+
 # 0.0.5
 
 - fix "onDestroy" event for iOS [#4](https://github.com/dart-flitter/flutter_webview_plugin/issues/4)

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -14,18 +14,18 @@ import io.flutter.plugin.common.PluginRegistry;
  * FlutterWebviewPlugin
  */
 public class FlutterWebviewPlugin implements MethodCallHandler {
-  private FlutterActivity activity;
+  private Activity activity;
   public static MethodChannel channel;
   private final int WEBVIEW_ACTIVITY_CODE = 1;
   private static final String CHANNEL_NAME = "flutter_webview_plugin";
 
   public static void registerWith(PluginRegistry.Registrar registrar) {
     channel = new MethodChannel(registrar.messenger(), CHANNEL_NAME);
-    FlutterWebviewPlugin instance = new FlutterWebviewPlugin((FlutterActivity) registrar.activity());
+    FlutterWebviewPlugin instance = new FlutterWebviewPlugin((Activity) registrar.activity());
     channel.setMethodCallHandler(instance);
   }
 
-  private FlutterWebviewPlugin(FlutterActivity activity) {
+  private FlutterWebviewPlugin(Activity activity) {
     this.activity = activity;
   }
 
@@ -62,4 +62,3 @@ public class FlutterWebviewPlugin implements MethodCallHandler {
     result.success(null);
   }
 }
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ authors:
 - Hadrien Lejard <hadrien.lejard@gmail.com>
 - Toufik Zitouni <toufiksapps@gmail.com>
 homepage: https://github.com/dart-flitter/flutter_webview_plugin
-version: 0.0.8
+version: 0.0.9
 
 flutter:
   plugin:


### PR DESCRIPTION
The WebView plugin wasn't compatible when you use FlutterFragmentActivity as base activity class instead of the default FlutterActivity. This pull request fixes that dependency by not needing to cast to FlutterActivity.