### PR TITLE
handle type error in getCookies

### DIFF
--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -143,7 +143,7 @@ class FlutterWebviewPlugin {
 
   Future<Map<String, dynamic>> getCookies() async {
     final cookiesString = await evalJavascript("document.cookie");
-    final cookies = {};
+    final cookies = <String, dynamic>{};
 
     if (cookiesString?.isNotEmpty == true) {
       cookiesString.split(";").forEach((String cookie) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -141,9 +141,9 @@ class FlutterWebviewPlugin {
     _instance = null;
   }
 
-  Future<Map<String, dynamic>> getCookies() async {
+  Future<Map<String, String>> getCookies() async {
     final cookiesString = await evalJavascript("document.cookie");
-    final cookies = <String, dynamic>{};
+    final cookies = <String, String>{};
 
     if (cookiesString?.isNotEmpty == true) {
       cookiesString.split(";").forEach((String cookie) {


### PR DESCRIPTION
from dart2, `getCookies` throws type conversion error.
Refer to https://stackoverflow.com/questions/49824167/breaking-exception-internallinkedhashmapdynamic-dynamic-is-not-a-subtype-o

And is there any reason that return type of `getCookies` is `Map<String, dynamic>` instead of `Map<String, String>`?