### PR TITLE
Add default minSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ android {
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        minSdkVersion 16
     }
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
This avoids some not needed permissions to be automatically included by Gradle during the Manifest merge phase.
It should be harmless otherwise, considering the Flutter's minSdkVersion is 16 anyways.