### PR TITLE
Fix for #134 - WebviewScaffold crash on iOS

### DIFF
--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -112,6 +112,8 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
       }
     }
 
+    if (height < 0.0) height = 0.0;
+
     return new Rect.fromLTWH(0.0, top, mediaQuery.size.width, height);
   }
 }


### PR DESCRIPTION
After closing and re-launching the app, the WebviewScaffold sometimes requests to resize the webview to a negative height. This causes a crash on iOS 11.4 / iPhone 6

#134 