### PR TITLE
Make WebViewStateChanged's navigationType nullable

### DIFF
--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -367,7 +367,7 @@ class WebViewStateChanged {
 
   final WebViewState type;
   final String url;
-  final int navigationType;
+  final int? navigationType;
 }
 
 class WebViewHttpError {


### PR DESCRIPTION
# Description

After updating our app to use the latest null-safety release, we realized the `onStateChanged` stream stopped working in our Android devices and emulators.

After a few hours of debugging with @wescosta, we realized `navigationType` wasn't defined in the `Map<String, dynamic>` - so making it nullable resolved the issue.

Now all our WebViews are back and working like they used to.

> Even the `example` project wasn't working before these changes. The `WebviewScaffold` with `hidden` was in a infinite "Waiting..." state.