### PR TITLE
Add a flag for forcing software rendering on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Future<Null> launch(String url, {
     bool geolocationEnabled: false,
     bool debuggingEnabled: false,
     bool ignoreSSLErrors: false,
+    bool softwareRender: false,
 });
 ```
 

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -128,6 +128,7 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         boolean geolocationEnabled = call.argument("geolocationEnabled");
         boolean debuggingEnabled = call.argument("debuggingEnabled");
         boolean ignoreSSLErrors = call.argument("ignoreSSLErrors");
+        boolean softwareRender = call.argument("softwareRender");
 
         if (webViewManager == null || webViewManager.closed == true) {
             Map<String, Object> arguments = (Map<String, Object>) call.arguments;
@@ -162,7 +163,8 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
                 invalidUrlRegex,
                 geolocationEnabled,
                 debuggingEnabled,
-                ignoreSSLErrors
+                ignoreSSLErrors,
+                softwareRender
         );
         result.success(null);
     }

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -380,7 +380,8 @@ class WebviewManager {
             String invalidUrlRegex,
             boolean geolocationEnabled,
             boolean debuggingEnabled,
-            boolean ignoreSSLErrors
+            boolean ignoreSSLErrors,
+            boolean softwareRender
     ) {
         webView.getSettings().setJavaScriptEnabled(withJavascript);
         webView.getSettings().setBuiltInZoomControls(withZoom);
@@ -438,6 +439,10 @@ class WebviewManager {
 
         if (!scrollBar) {
             webView.setVerticalScrollBarEnabled(false);
+        }
+
+        if (softwareRender) {
+            webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
         }
 
         if (headers != null) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -139,6 +139,7 @@ class FlutterWebviewPlugin {
   /// - [withOverviewMode]: enable overview mode for Android webview ( setLoadWithOverviewMode )
   /// - [useWideViewPort]: use wide viewport for Android webview ( setUseWideViewPort )
   /// - [ignoreSSLErrors]: use to bypass Android/iOS SSL checks e.g. for self-signed certificates
+  /// - [softwareRender]: use to force software rendering on Android
   Future<void> launch(
     String url, {
     Map<String, String>? headers,
@@ -166,6 +167,7 @@ class FlutterWebviewPlugin {
     bool geolocationEnabled = false,
     bool debuggingEnabled = false,
     bool ignoreSSLErrors = false,
+    bool softwareRender = false,
   }) async {
     final args = <String, dynamic>{
       'url': url,
@@ -191,6 +193,7 @@ class FlutterWebviewPlugin {
       'withOverviewMode': withOverviewMode,
       'debuggingEnabled': debuggingEnabled,
       'ignoreSSLErrors': ignoreSSLErrors,
+      'softwareRender' : softwareRender,
     };
 
     if (headers != null) {


### PR DESCRIPTION
Mostly useful for a workaround for [a bug on Samsung S9](https://stackoverflow.com/questions/49645746/s9-s9-specific-webview-device-crash-report).
